### PR TITLE
Various fixes (ruby 1.9 and bundler) and internals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in uwn-api.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,42 @@
+PATH
+  remote: .
+  specs:
+    rubypython (0.6.3)
+      blankslate (>= 2.1.2.3)
+      ffi (>= 1.0.7)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (3.1.2)
+    diff-lcs (1.2.4)
+    ffi (1.8.1-java)
+    hoe (3.6.1)
+      rake (>= 0.8, < 11.0)
+    json (1.8.0-java)
+    json_pure (1.8.0)
+    rake (10.0.4)
+    rdoc (4.0.1)
+      json (~> 1.4)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
+    tilt (1.4.1)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  hoe (~> 3.6)
+  rdoc (~> 4.0)
+  rspec (~> 2.0)
+  rubyforge (>= 2.0.4)
+  rubypython!
+  tilt (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubypython (0.6.3)
+    rubypython (0.6.4)
       blankslate (>= 2.1.2.3)
       ffi (>= 1.0.7)
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -127,6 +127,8 @@ start before running the code provided in the block and stop it afterwards.
 
 This format is experimental and may be changed.
 
+NOTE: bang is used because it's difficult to distinguish between passing dicts or named arguments.
+
   # Python
   def foo(arg1, arg2):
     pass
@@ -259,7 +261,7 @@ It should work with other implementations that support the Ruby FFI gem with no
 modification.
 
 === OS Support
-RubyPython has been extensively tested on Mac OS 10.5 and 10.6, and Ubuntu
+RubyPython has been extensively tested on Mac OS 10.5, 10.6, and 10.8 and Ubuntu
 10.10 (64-bit Intel). If your platform has a DLL or shared object version of
 Python and supports the FFI gem, it should work. Feedback on other platforms is
 always welcome.

--- a/lib/rubypython.rb
+++ b/lib/rubypython.rb
@@ -213,7 +213,8 @@ module RubyPython
     end
 
     def initialized?
-      RubyPython::Python.Py_IsInitialized != 0
+      return RubyPython::Python.Py_IsInitialized != 0 if RubyPython::Python.const_defined?(:Py_IsInitialized)
+      false
     end
 
     # Used to activate the virtualenv.

--- a/lib/rubypython.rb
+++ b/lib/rubypython.rb
@@ -14,9 +14,6 @@
 #   cPickle = RubyPython.import "cPickle"
 #   puts cPickle.dumps("RubyPython is awesome!").rubify
 #   RubyPython.stop
-module RubyPython
-  VERSION = '0.6.3'
-end
 
 require 'rubypython/blankobject'
 require 'rubypython/interpreter'
@@ -27,6 +24,8 @@ require 'rubypython/rubypyproxy'
 require 'rubypython/pymainclass'
 require 'rubypython/pygenerator'
 require 'rubypython/tuple'
+require 'rubypython/version'
+
 require 'thread'
 
 module RubyPython

--- a/lib/rubypython.rb
+++ b/lib/rubypython.rb
@@ -212,6 +212,10 @@ module RubyPython
       end
     end
 
+    def initialized?
+      RubyPython::Python.Py_IsInitialized != 0
+    end
+
     # Used to activate the virtualenv.
     def activate_virtualenv
       imp = import("imp")

--- a/lib/rubypython.rb
+++ b/lib/rubypython.rb
@@ -15,6 +15,10 @@
 #   puts cPickle.dumps("RubyPython is awesome!").rubify
 #   RubyPython.stop
 
+module RubyPython
+  # module init placeholder
+end
+
 require 'rubypython/blankobject'
 require 'rubypython/interpreter'
 require 'rubypython/python'

--- a/lib/rubypython/conversion.rb
+++ b/lib/rubypython/conversion.rb
@@ -288,8 +288,8 @@ module RubyPython::Conversion
       pVal = val.read_pointer
       rKey = ptorObject(pKey)
       rVal = ptorObject(pVal)
-      RubyPython.Py_IncRef pKey if rKey.kind_of? ::FFI::Pointer
-      RubyPython.Py_IncRef pVal if rVal.kind_of? ::FFI::Pointer
+      RubyPython::Python.Py_IncRef pKey if rKey.kind_of? ::FFI::Pointer
+      RubyPython::Python.Py_IncRef pVal if rVal.kind_of? ::FFI::Pointer
       rb_hash[rKey] = rVal
     end
 

--- a/lib/rubypython/interpreter.rb
+++ b/lib/rubypython/interpreter.rb
@@ -55,6 +55,8 @@ class RubyPython::Interpreter
     rc, @version    = runpy "import sys; print '%d.%d' % sys.version_info[:2]"
     rc, @sys_prefix = runpy "import sys; print sys.prefix"
 
+    @realname = "#{@python}#{@version}"
+
     if ::FFI::Platform.windows?
       flat_version  = @version.tr('.', '')
       basename      = File.basename(@python, '.exe')
@@ -74,14 +76,13 @@ class RubyPython::Interpreter
         @version_name = "#{basename}#{@version}"
       end
     end
-
     @library = find_python_lib
   end
 
   def find_python_lib
     # By default, the library name will be something like
     # libpython2.6.so, but that won't always work.
-    @libbase = "#{::FFI::Platform::LIBPREFIX}#{@version_name}"
+    @libbase = "#{::FFI::Platform::LIBPREFIX}#{@realname}"
     @libext = ::FFI::Platform::LIBSUFFIX
     @libname = "#{@libbase}.#{@libext}"
 
@@ -154,7 +155,7 @@ class RubyPython::Interpreter
         library = location
         break
       end
-    end
+    end 
 
     library
   end

--- a/lib/rubypython/interpreter.rb
+++ b/lib/rubypython/interpreter.rb
@@ -38,6 +38,7 @@ class RubyPython::Interpreter
   #   run.
   def initialize(options = {})
     @python_exe = options[:python_exe]
+    @library = options[:library] if options.include? :library
     # Windows: 'C:\\Python27\python.exe'
     # Mac OS X: '/usr/bin/
 
@@ -76,7 +77,7 @@ class RubyPython::Interpreter
         @version_name = "#{basename}#{@version}"
       end
     end
-    @library = find_python_lib
+    @library ||= find_python_lib
   end
 
   def find_python_lib

--- a/lib/rubypython/interpreter.rb
+++ b/lib/rubypython/interpreter.rb
@@ -140,6 +140,7 @@ class RubyPython::Interpreter
     @locations.dup.each do |location|
       path = File.dirname(location)
       base = File.basename(location, ".#{@libext}")
+      @locations << File.join(path, "#{base}.so.1")    # Standard Unix
       @locations << File.join(path, "#{base}.so")    # Standard Unix
       @locations << File.join(path, "#{base}.dylib") # Mac OS X
       @locations << File.join(path, "#{base}.dll")   # Windows

--- a/lib/rubypython/version.rb
+++ b/lib/rubypython/version.rb
@@ -1,3 +1,3 @@
 module RubyPython
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/lib/rubypython/version.rb
+++ b/lib/rubypython/version.rb
@@ -1,0 +1,3 @@
+module RubyPython
+  VERSION = "0.6.3"
+end

--- a/rubypython.gemspec
+++ b/rubypython.gemspec
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'rubypython/version'
+
+Gem::Specification.new do |s|
+  s.name = "rubypython"
+  s.version = RubyPython::VERSION
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Steeve Morin", "Austin Ziegler", "Zach Raines"]
+  s.date = "2013-05-23"
+  s.description = "RubyPython is a bridge between the Ruby and Python interpreters. It embeds a\nrunning Python interpreter in the Ruby application's process using FFI and\nprovides a means for wrapping, converting, and calling Python objects and\nmethods.\n\nRubyPython uses FFI to marshal the data between the Ruby and Python VMs and\nmake Python calls. You can:\n\n* Inherit from Python classes.\n* Configure callbacks from Python.\n* Run Python generators (on Ruby 1.9.2 or later)."
+  s.email = ["swiuzzz+rubypython@gmail.com", "austin@rubyforge.org", "raineszm+rubypython@gmail.com"]
+  s.extra_rdoc_files = ["Contributors.rdoc", "History.rdoc", "License.rdoc", "Manifest.txt", "PostInstall.txt", "README.rdoc", "Contributors.rdoc", "History.rdoc", "License.rdoc", "README.rdoc"]
+  
+  s.files = `git ls-files`.split($/)
+  s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths = ["lib"]
+
+  s.rdoc_options = ["--main", "README.rdoc"]
+  s.require_paths = ["lib"]
+  s.requirements = ["Python, ~> 2.4"]
+  s.rubyforge_project = "rubypython"
+  s.rubygems_version = "2.0.3"
+  s.summary = "RubyPython is a bridge between the Ruby and Python interpreters"
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<ffi>, [">= 1.0.7"])
+      s.add_runtime_dependency(%q<blankslate>, [">= 2.1.2.3"])
+      s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
+      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_development_dependency(%q<rspec>, ["~> 2.0"])
+      s.add_development_dependency(%q<tilt>, ["~> 1.0"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.6"])
+    else
+      s.add_dependency(%q<ffi>, [">= 1.0.7"])
+      s.add_dependency(%q<blankslate>, [">= 2.1.2.3"])
+      s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
+      s.add_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_dependency(%q<rspec>, ["~> 2.0"])
+      s.add_dependency(%q<tilt>, ["~> 1.0"])
+      s.add_dependency(%q<hoe>, ["~> 3.6"])
+    end
+  else
+    s.add_dependency(%q<ffi>, [">= 1.0.7"])
+    s.add_dependency(%q<blankslate>, [">= 2.1.2.3"])
+    s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
+    s.add_dependency(%q<rdoc>, ["~> 4.0"])
+    s.add_dependency(%q<rspec>, ["~> 2.0"])
+    s.add_dependency(%q<tilt>, ["~> 1.0"])
+    s.add_dependency(%q<hoe>, ["~> 3.6"])
+  end
+end

--- a/spec/python_helpers/objects.py
+++ b/spec/python_helpers/objects.py
@@ -12,6 +12,15 @@ def named_args(arg1, arg2):
 def optional_named_args(arg1="abc", arg2="def"):
   return arg1 + arg2
 
+def str_type_level0(object):
+  return str(type(object))
+
+def str_type_level1(object):
+  return str(type(object[0]))
+
+def str_type_level2(object):
+  return str(type(object[0][0]))
+
 class RubyPythonMockObject:
   STRING = "STRING"
   STRING_LIST = ["STRING1", "STRING2"]

--- a/spec/python_helpers/objects.py
+++ b/spec/python_helpers/objects.py
@@ -9,6 +9,9 @@ def apply_callback(callback, args):
 def named_args(arg1, arg2):
   return [arg2*2, arg1*2]
 
+def optional_named_args(arg1="abc", arg2="def"):
+  return arg1 + arg2
+
 class RubyPythonMockObject:
   STRING = "STRING"
   STRING_LIST = ["STRING1", "STRING2"]

--- a/spec/rubypyproxy_spec.rb
+++ b/spec/rubypyproxy_spec.rb
@@ -169,6 +169,12 @@ describe RubyPython::RubyPyProxy do
       @objects.named_args!(:arg2 => 2, :arg1 => 1).rubify.should == [4,2]
     end
 
+    it "should pass named args via bang method for optional params" do
+      @objects.optional_named_args!().rubify.should == "abcdef"
+      @objects.optional_named_args!(arg1: 'que', arg2: 'ing').rubify.should == "queing"
+      @objects.optional_named_args!(arg2: 'ing').rubify.should == "abcing"
+    end
+
     it "should pass through keyword arguments via bang method" do
       builtinProxy = described_class.new @builtin
       builtinProxy.dict!({'dict'=>'val'}, :keyword=>true).rubify.should == {

--- a/spec/rubypyproxy_spec.rb
+++ b/spec/rubypyproxy_spec.rb
@@ -175,6 +175,21 @@ describe RubyPython::RubyPyProxy do
       @objects.optional_named_args!(arg2: 'ing').rubify.should == "abcing"
     end
 
+    it "should pass tuples parameters" do
+      @objects.str_type_level0( RubyPython::Tuple.tuple(['a', 1, 4.1]) ).rubify.should == "<type 'tuple'>"
+      @objects.str_type_level1( [ RubyPython::Tuple.tuple(['a', 1, 4.1]) ] ).rubify.should == "<type 'tuple'>"
+    end
+
+    it "should pass list parameters" do
+      @objects.str_type_level0( ['a', 1, 4.1] ).rubify.should == "<type 'list'>"
+      @objects.str_type_level1( [ ['a', 1, 4.1] ] ).rubify.should == "<type 'list'>"
+    end
+
+    it "should pass dict parameters" do
+      @objects.str_type_level0( {key: 'value'} ).rubify.should == "<type 'dict'>"
+      @objects.str_type_level1( [ {key: 'value'} ] ).rubify.should == "<type 'dict'>"
+    end
+    
     it "should pass through keyword arguments via bang method" do
       builtinProxy = described_class.new @builtin
       builtinProxy.dict!({'dict'=>'val'}, :keyword=>true).rubify.should == {


### PR DESCRIPTION
Fixed support for Ruby 1.9, gemspec. Extracted VERSION to a separate file, and changed file extensions for additional files (*.rdoc). For use with JRuby 1.7.3, and bundler 3.0.4.

Internally I've fixed: Import nested modules/ packages, Conversion reference Py_IncRef,
interpreter real name target instead of library (as https://github.com/steeve/rupy does); Added tests for optional named args functions (rspec and python function).

PS. I require some python native packages in my rails environment, to completed the bridge for my needs I've fixed/ added the above (some other fixes might follow).
